### PR TITLE
:chart_with_upwards_trend: Enable Prysm metrics

### DIFF
--- a/terraform/gce-with-container/network.tf
+++ b/terraform/gce-with-container/network.tf
@@ -106,6 +106,19 @@ resource "google_compute_firewall" "allow_tag_prysm_p2p" {
   }
 }
 
+resource "google_compute_firewall" "allow_tag_prysm_metrics" {
+  count         = var.create_firewall_rule ? 1 : 0
+  name          = "${var.prefix}-${local.instance_name}-ingress-tag-prysm-metrics-${var.environment}"
+  description   = "Ingress to allow prysm metrics port to machines with the 'prysm-metrics' tag"
+  network       = var.network_name
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["prysm-metrics"]
+  allow {
+    protocol = "tcp"
+    ports    = [var.prysm_metrics_port]
+  }
+}
+
 resource "google_compute_address" "static" {
   name = "${var.prefix}-${local.instance_name}-address-${var.environment}"
 }

--- a/terraform/gce-with-container/variables.tf
+++ b/terraform/gce-with-container/variables.tf
@@ -71,6 +71,12 @@ variable "prysm_p2p_port" {
   default     = 13000
 }
 
+variable "prysm_metrics_port" {
+  description = "Port for metrics."
+  type        = number
+  default     = 8080
+}
+
 variable "datadir_disk_size" {
   description = "Persistent disk size (GB) used for the datadir"
   type        = number

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -94,6 +94,8 @@ module "gce_prysm_worker_container" {
     var.checkpoint_sync_url,
     "--genesis-beacon-api-url",
     var.genesis_beacon_api_url,
+    "--monitoring-host",
+    "0.0.0.0",
   ]
   privileged_mode  = true
   activate_tty     = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -55,7 +55,7 @@ variable "geth_vm_tags" {
 variable "prysm_vm_tags" {
   description = "Additional network tags for the geth instances."
   type        = list(string)
-  default     = ["prysm-rpc", "prysm-p2p-udp", "prysm-p2p"]
+  default     = ["prysm-rpc", "prysm-p2p-udp", "prysm-p2p", "prysm-metrics"]
 }
 
 variable "jwt_hex_path" {


### PR DESCRIPTION
Enable the Beacon node metrics.
Note that the metrics don't include the core VM metrics such as CPU, RAM, disk, network. So we may need to expose them later using the Prometheus node exporter or try to import Google Cloud Monitoring as a data source