### PR TITLE
:money_with_wings: Optimize VM cost

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,7 +58,7 @@ module "gce_geth_worker_container" {
   ]
   privileged_mode      = true
   activate_tty         = true
-  machine_type         = var.machine_type
+  machine_type         = var.geth_machine_type
   prefix               = local.service_name
   environment          = local.environment
   env_variables        = {}
@@ -99,7 +99,7 @@ module "gce_prysm_worker_container" {
   ]
   privileged_mode  = true
   activate_tty     = true
-  machine_type     = var.machine_type
+  machine_type     = var.prysm_machine_type
   prefix           = local.service_name
   environment      = local.environment
   env_variables    = {}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -8,7 +8,8 @@ region  = "us-central1"
 zone    = "us-central1-a"
 
 ## Common node setup
-machine_type = "e2-standard-4"
+geth_machine_type  = "e2-standard-4"
+prysm_machine_type = "e2-standard-2"
 ssh_keys = {
   "andre" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCXL0+ecc//lAJhiY0YIpKjkHXA7SUv4ouw+29Gps8YYme8fzTn7/gWWO11ALqqqycoJuLn7CBzCRWrUmxn1u2XsEQyaYmfbRKAUktbevHgJtQv2l8OhAmWFhRKvuMA/J5L5jY4FoozC0iQywQWLbC4Vzh7gjwxmqS7PPbamzE6xa45aI4AsxPHN1Ac2tUuuow5ILGC4Vw2bHa/7k5dnwLTGFAIJIXAn4nullC5y4hLQMJPK7NzW+77PKXzEJEye26c98rEbqdzNBnxjz+TH0B6IMZ6GtnmjArCMJPbWfitjBc8Qf/q5X8akoPQqZpkqu/ZB/MXrhfxz400PjZ0yYK710bL+wC0oeEgjlFxfuBPCICSiJqTRVr6O4tkDG3axnqPWKQjUlXkMkQkMjjZy0oZmF1/mffdODuJ6ALicREjKAcS+yOzVcJP9ZqMFHwLhaGLYjCGy//w6q/R2uVm51qEOiWP824ESIFzOQly6Udh1Jeue5JRCaAuZv+6wP4RNO8="
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -42,7 +42,11 @@ variable "create_firewall_rule" {
   default     = false
 }
 
-variable "machine_type" {
+variable "geth_machine_type" {
+  type = string
+}
+
+variable "prysm_machine_type" {
   type = string
 }
 


### PR DESCRIPTION
Set the Prysm beacon node to e2-standard-2 instead of e2-standard-4 to save about $50/month.
- e2-standard-4 (4 cores, 16G of RAM) at ~$100/month
- e2-standard-2 (2 cores, 8G of RAM) at ~$50/month

refs:
- https://www.economize.cloud/resources/gcp/pricing/e2/e2-standard-4
- https://www.economize.cloud/resources/gcp/pricing/e2/e2-standard-2