### PR TITLE
:lock: Configurable Geth RPC IP source range

### DIFF
--- a/terraform/gce-with-container/network.tf
+++ b/terraform/gce-with-container/network.tf
@@ -16,7 +16,7 @@ resource "google_compute_firewall" "allow_tag_geth_http_rpc" {
   name          = "${var.prefix}-${local.instance_name}-ingress-tag-geth-http-rpc-${var.environment}"
   description   = "Ingress to allow geth HTTP RPC ports to machines with the 'geth-http-rpc' tag"
   network       = var.network_name
-  source_ranges = ["0.0.0.0/0"]
+  source_ranges = var.geth_rpc_source_range
   target_tags   = ["geth-http-rpc"]
   allow {
     protocol = "tcp"
@@ -29,7 +29,7 @@ resource "google_compute_firewall" "allow_tag_geth_ws_rpc" {
   name          = "${var.prefix}-${local.instance_name}-ingress-tag-geth-ws-rpc-${var.environment}"
   description   = "Ingress to allow geth HTTP WS RPC ports to machines with the 'geth-ws-rpc' tag"
   network       = var.network_name
-  source_ranges = ["0.0.0.0/0"]
+  source_ranges = var.geth_rpc_source_range
   target_tags   = ["geth-ws-rpc"]
   allow {
     protocol = "tcp"

--- a/terraform/gce-with-container/variables.tf
+++ b/terraform/gce-with-container/variables.tf
@@ -53,6 +53,12 @@ variable "geth_ws_rpc_port" {
   default     = 8546
 }
 
+variable "geth_rpc_source_range" {
+  description = "Allowed IP source range for (unauthenticated) RPC related call."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
 variable "geth_p2p_port" {
   description = "Port for P2P."
   type        = number

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,17 +58,18 @@ module "gce_geth_worker_container" {
     "--pprof.addr",
     "0.0.0.0",
   ]
-  privileged_mode      = true
-  activate_tty         = true
-  machine_type         = var.geth_machine_type
-  prefix               = local.service_name
-  environment          = local.environment
-  env_variables        = {}
-  instance_name        = "geth"
-  network_name         = "default"
-  create_static_ip     = true
-  create_firewall_rule = var.create_firewall_rule
-  vm_tags              = var.geth_vm_tags
+  privileged_mode       = true
+  activate_tty          = true
+  machine_type          = var.geth_machine_type
+  prefix                = local.service_name
+  environment           = local.environment
+  env_variables         = {}
+  instance_name         = "geth"
+  network_name          = "default"
+  create_static_ip      = true
+  create_firewall_rule  = var.create_firewall_rule
+  geth_rpc_source_range = var.geth_rpc_source_range
+  vm_tags               = var.geth_vm_tags
   # This has the permission to download images from Container Registry
   client_email      = var.client_email
   ssh_keys          = var.ssh_keys

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -94,6 +94,12 @@ variable "datadir_host_path" {
   default = "/mnt/disks/sdb"
 }
 
+variable "geth_rpc_source_range" {
+  description = "Allowed IP source range for (unauthenticated) RPC related call."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
 variable "execution_endpoint" {
   type = string
 }


### PR DESCRIPTION
Make it easier to whitelist/firewall source IP on unauthenticated Geth RPC endpoints.