### PR TITLE
:wrench: Bump Prysm VM memory to 16G

### DIFF
--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -9,7 +9,7 @@ zone    = "us-central1-a"
 
 ## Common node setup
 geth_machine_type  = "e2-standard-4"
-prysm_machine_type = "e2-standard-2"
+prysm_machine_type = "e2-highmem-2"
 ssh_keys = {
   "andre" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCXL0+ecc//lAJhiY0YIpKjkHXA7SUv4ouw+29Gps8YYme8fzTn7/gWWO11ALqqqycoJuLn7CBzCRWrUmxn1u2XsEQyaYmfbRKAUktbevHgJtQv2l8OhAmWFhRKvuMA/J5L5jY4FoozC0iQywQWLbC4Vzh7gjwxmqS7PPbamzE6xa45aI4AsxPHN1Ac2tUuuow5ILGC4Vw2bHa/7k5dnwLTGFAIJIXAn4nullC5y4hLQMJPK7NzW+77PKXzEJEye26c98rEbqdzNBnxjz+TH0B6IMZ6GtnmjArCMJPbWfitjBc8Qf/q5X8akoPQqZpkqu/ZB/MXrhfxz400PjZ0yYK710bL+wC0oeEgjlFxfuBPCICSiJqTRVr6O4tkDG3axnqPWKQjUlXkMkQkMjjZy0oZmF1/mffdODuJ6ALicREjKAcS+yOzVcJP9ZqMFHwLhaGLYjCGy//w6q/R2uVm51qEOiWP824ESIFzOQly6Udh1Jeue5JRCaAuZv+6wP4RNO8="
 }


### PR DESCRIPTION
From e2-standard-2: 2 cores, 8G of memory at $48.92/month
To e2-highmem-2: 2 cores, 16G of memory at $65.99/month

This should prevent the node from swapping, refs:
https://ansybl.slack.com/archives/C04KVUV54KU/p1683667405403489

![image](https://github.com/ansybl/eth-infra/assets/24973/be029ff6-c7b4-4bf9-afe2-80ccc2ea7b8c)