### PR TITLE
:construction_worker: CI SSH key pair

### DIFF
--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -17,6 +17,7 @@ env:
   INSTANCE_NAME: eth-node-geth-c84e80e6-mainnet
   PROJECT: dfpl-playground
   ZONE: us-central1-a
+  SSH_KEYFILE: google_compute_engine
 
 jobs:
   smoketests:
@@ -24,9 +25,15 @@ jobs:
     env:
       PROVIDER_URL: ${{ github.event.inputs.provider_url || 'http://localhost:8545' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: google-github-actions/setup-gcloud@v1
       - run: echo '${{ secrets.GOOGLE_CREDENTIALS }}' > $CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+      - name: Init SSH key pairs
+        run: |
+          mkdir -p ~/.ssh
+          echo '${{ secrets.PRIVATE_SSH_KEY }}' > ~/.ssh/$SSH_KEYFILE
+          chmod 600 ~/.ssh/$SSH_KEYFILE
+          ssh-keygen -f ~/.ssh/$SSH_KEYFILE -y > ~/.ssh/$SSH_KEYFILE.pub
       - name: Open SSH tunnel
         run: |
           gcloud compute ssh \


### PR DESCRIPTION
This is to avoid a new key pairs being generated each run which led to having hundred of pub keys deployed in GCP later