### PR TITLE
:technologist: Add reset (reboot) VMs Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,16 @@ devops/terraform/redeploy/geth: devops/terraform/redeploy/vm/geth
 devops/terraform/redeploy: devops/terraform/redeploy/prysm devops/terraform/redeploy/geth
 	make devops/terraform/apply
 
+devops/terraform/reset/vm/%:
+	gcloud --project $(PROJECT) compute instances reset $*
+
+devops/terraform/reset/prysm: devops/terraform/reset/vm/eth-node-prysm-cdb502a9-$(WORKSPACE)
+
+# make sure to gracefully stop the geth container to avoid chain data corruption
+devops/terraform/reset/geth: devops/terraform/reset/vm/eth-node-geth-c84e80e6-$(WORKSPACE)
+
+devops/terraform/reset: devops/terraform/reset/prysm devops/terraform/reset/geth
+
 devops/terraform/destroy/all: devops/terraform/select/$(WORKSPACE)
 	terraform -chdir=terraform destroy
 


### PR DESCRIPTION
Reboot both prysm and geth:
```
make devops/terraform/reset
```
Or individually:
```
make devops/terraform/reset/prysm
make devops/terraform/reset/geth
```

Geth container must first be stopped gracefully to prevent the chain data from being corrupted (Head state missing, repairing).