### PR TITLE
:technologist: Add reset (reboot) VMs Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,16 @@ devops/terraform/redeploy/geth: devops/terraform/redeploy/vm/geth
 devops/terraform/redeploy: devops/terraform/redeploy/prysm devops/terraform/redeploy/geth
 	make devops/terraform/apply
 
+devops/terraform/reset/vm/%:
+	gcloud --project $(PROJECT) compute instances reset $*
+
+devops/terraform/reset/prysm: devops/terraform/reset/vm/eth-node-prysm-cdb502a9-$(WORKSPACE)
+
+# make sure to gracefully stop the geth container to avoid chain data corruption
+devops/terraform/reset/geth: devops/terraform/reset/vm/eth-node-geth-c84e80e6-$(WORKSPACE)
+
+devops/terraform/reset: devops/terraform/reset/prysm devops/terraform/reset/geth
+
 devops/terraform/destroy/all: devops/terraform/select/$(WORKSPACE)
 	terraform -chdir=terraform destroy
 

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -15,6 +15,7 @@ create_firewall_rule = true
 ## Geth node specific
 geth_rpc_source_range = [
   # Google Cloud Platform
+  "34.16.0.0/16",
   "34.122.0.0/16",
   "34.170.0.0/17",
   "104.197.16.0/20",
@@ -22,4 +23,4 @@ geth_rpc_source_range = [
 
 ## Prysm node specific
 # Pointing to our geth node
-execution_endpoint = "http://35.222.198.26:8551"
+execution_endpoint = "http://geth-node.ansybl.io:8551"


### PR DESCRIPTION
Reboot both prysm and geth:
```
make devops/terraform/reset
```
Or individually:
```
make devops/terraform/reset/prysm
make devops/terraform/reset/geth
```

Geth container must first be stopped gracefully to prevent the chain data from being corrupted (Head state missing, repairing).

Also add more IP to the whitelisting.