### PR TITLE
:technologist: Add reset (reboot) VMs Makefile target

### DIFF
--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -16,6 +16,7 @@ create_firewall_rule = true
 geth_rpc_source_range = [
   # Google Cloud Platform
   "34.16.0.0/16",
+  "34.66.0.0/16",
   "34.122.0.0/16",
   "34.170.0.0/17",
   "104.197.16.0/20",


### PR DESCRIPTION
Reboot both prysm and geth:
```
make devops/terraform/reset
```
Or individually:
```
make devops/terraform/reset/prysm
make devops/terraform/reset/geth
```

Geth container must first be stopped gracefully to prevent the chain data from being corrupted (Head state missing, repairing).

Also add more IP to the whitelisting.