### PR TITLE
:wrench: Bump geth disk size and update version

### DIFF
--- a/terraform/gce-with-container/main.tf
+++ b/terraform/gce-with-container/main.tf
@@ -8,7 +8,7 @@ locals {
   }]
 }
 
-####################
+#####################
 ##### CONTAINER SETUP
 
 module "gce-container" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,7 +29,7 @@ variable "geth_image" {
 
 variable "geth_image_tag" {
   type    = string
-  default = "v1.13.14"
+  default = "v1.14.5"
 }
 
 variable "prysm_image" {
@@ -80,7 +80,7 @@ variable "jwt_hex_host_path" {
 
 variable "geth_datadir_disk_size" {
   type    = number
-  default = 2000
+  default = 2500
 }
 
 variable "prysm_datadir_disk_size" {


### PR DESCRIPTION
- bump disk size from 2T to 2.5T
- bump geth version from v1.13.14 to v1.14.5

Partition was later resized with:
```
sudo resize2fs /dev/sdb
```